### PR TITLE
Remove SQL debugging statement

### DIFF
--- a/lib/delayed/backend/sequel.rb
+++ b/lib/delayed/backend/sequel.rb
@@ -51,7 +51,9 @@ module Delayed
                        now, now - max_run_time, worker_name)
             scope = scope.where(:priority >= Worker.min_priority) if Worker.min_priority
             scope = scope.where(:priority <= Worker.max_priority) if Worker.max_priority
-            scope.order(:priority.desc, :run_at.asc).limit(limit).all
+            scope = scope.order(:priority.desc, :run_at.asc).limit(limit)
+            p scope.sql
+            scope.all
           end
 
           # When a worker is exiting, make sure we don't have any locked jobs.

--- a/lib/delayed/backend/sequel.rb
+++ b/lib/delayed/backend/sequel.rb
@@ -51,9 +51,7 @@ module Delayed
                        now, now - max_run_time, worker_name)
             scope = scope.where(:priority >= Worker.min_priority) if Worker.min_priority
             scope = scope.where(:priority <= Worker.max_priority) if Worker.max_priority
-            scope = scope.order(:priority.desc, :run_at.asc).limit(limit)
-            p scope.sql
-            scope.all
+            scope.order(:priority.desc, :run_at.asc).limit(limit).all
           end
 
           # When a worker is exiting, make sure we don't have any locked jobs.

--- a/lib/delayed/backend/sequel.rb
+++ b/lib/delayed/backend/sequel.rb
@@ -52,7 +52,6 @@ module Delayed
             filters << "priority >= #{Worker.min_priority.to_i}" if Worker.min_priority
             filters << "priority <= #{Worker.max_priority.to_i}" if Worker.max_priority
             ds = Job.filter(filters.join(' and ')).order(:priority.desc, :run_at.asc).limit(limit)
-            p ds.sql
             ds.all()
           end
 


### PR DESCRIPTION
# find_available contains a debugging print statement that prints out SQL each time Delayed::Job searches for available jobs.  This patch removes that line.
